### PR TITLE
give the session for test requests an ephemeral (in memory) cache.

### DIFF
--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/APIRequestTestSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/APIRequestTestSwiftGen.swift
@@ -241,6 +241,11 @@ public struct APIRequestTestSwiftGen: SwiftGenerator {
 
 private let makeTestRequestFunc = #"""
 
+/// A session stored globally that does not cache responses on disk.
+let session = URLSession(
+    configuration: .ephemeral
+)
+
 /// Log warning after test case logs
 func XCTWarn(_ message: String, at url: URL) {
     print("[\(url.absoluteString)] : warning - \(message)")
@@ -401,7 +406,7 @@ func makeTestRequest<RequestBody>(
         completionExpectation.fulfill()
     }
 
-    let task = URLSession.shared.dataTask(with: request, completionHandler: taskCompletion)
+    let task = session.dataTask(with: request, completionHandler: taskCompletion)
     task.resume()
 
     XCTWaiter().wait(for: [completionExpectation], timeout: 5)

--- a/Tests/JSONAPISwiftGenTests/APIRequestTestSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/APIRequestTestSwiftGenTests.swift
@@ -18,6 +18,11 @@ final class APIRequestTestSwiftGenTests: XCTestCase {
 }
 
 // MARK: - START - Function written to generated test suites
+/// A session stored globally that does not cache responses on disk.
+let session = URLSession(
+    configuration: .ephemeral
+)
+
 /// Log warning after test case logs
 func XCTWarn(_ message: String, at url: URL) {
     print("[\(url.absoluteString)] : warning - \(message)")
@@ -178,7 +183,7 @@ func makeTestRequest<RequestBody>(
         completionExpectation.fulfill()
     }
 
-    let task = URLSession.shared.dataTask(with: request, completionHandler: taskCompletion)
+    let task = session.dataTask(with: request, completionHandler: taskCompletion)
     task.resume()
 
     XCTWaiter().wait(for: [completionExpectation], timeout: 5)


### PR DESCRIPTION
Closes https://github.com/mattpolzin/JSONAPI-OpenAPI/issues/10.