### PR TITLE
Named example parse tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mattpolzin/JSONAPI.git",
         "state": {
           "branch": null,
-          "revision": "c645c73f51808b85a881e8af6f286086ee65cc35",
-          "version": "5.0.0"
+          "revision": "717f3d610e87705adca2bb91a03fd4e92c433845",
+          "version": "5.0.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/mattpolzin/Poly.git",
         "state": {
           "branch": null,
-          "revision": "36ba3f624bffa34f5f9b9c7648eab3cfdcab4748",
-          "version": "2.5.0"
+          "revision": "7dd2d0d3e6c0625f36f1b8306a90db12719240c8",
+          "version": "2.5.2"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "1bce5b89a11912fb8a8c48bd404bd24979472f27",
-          "version": "4.0.3"
+          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
+          "version": "4.0.4"
         }
       }
     ]

--- a/Sources/JSONAPISwiftGen/ResourceObjectSwiftGenCollection.swift
+++ b/Sources/JSONAPISwiftGen/ResourceObjectSwiftGenCollection.swift
@@ -103,7 +103,8 @@ func documents(
                         try OpenAPIExampleParseTestSwiftGen(
                             exampleDataPropName: examplePropName,
                             bodyType: responseBodyType,
-                            exampleHttpStatusCode: statusCode
+                            exampleHttpStatusCode: statusCode,
+                            exampleName: "default"
                         )
                     )
                 }
@@ -137,7 +138,8 @@ func documents(
                         try OpenAPIExampleParseTestSwiftGen(
                             exampleDataPropName: examplePropName,
                             bodyType: responseBodyType,
-                            exampleHttpStatusCode: statusCode
+                            exampleHttpStatusCode: statusCode,
+                            exampleName: propertyCased(name)
                         )
                     )
                 } catch let err {

--- a/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/DocumentSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/DocumentSwiftGen.swift
@@ -7,7 +7,7 @@
 
 public protocol DocumentSwiftGenerator: JSONSchemaSwiftGenerator {
     var swiftTypeName: String { get }
-    var exampleGenerator: ExampleSwiftGen? { get }
+    var exampleGenerators: [ExampleSwiftGen] { get }
     var testExampleFuncs: [TestFunctionGenerator] { get }
 
     var swiftCodeDependencies: [SwiftGenerator] { get }

--- a/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/JSONAPIDocumentSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/JSONAPIDocumentSwiftGen.swift
@@ -18,7 +18,7 @@ public struct JSONAPIDocumentSwiftGen: DocumentSwiftGenerator {
     public let decls: [Decl]
     public let swiftTypeName: String
     public let resourceObjectGenerators: Set<ResourceObjectSwiftGen>
-    public let exampleGenerator: ExampleSwiftGen?
+    public let exampleGenerators: [ExampleSwiftGen]
     public let testExampleFuncs: [TestFunctionGenerator]
 
     public var swiftCodeDependencies: [SwiftGenerator] {
@@ -29,12 +29,12 @@ public struct JSONAPIDocumentSwiftGen: DocumentSwiftGenerator {
         swiftTypeName: String,
         structure: DereferencedJSONSchema,
         allowPlaceholders: Bool = true,
-        example: ExampleSwiftGen? = nil,
+        examples: [ExampleSwiftGen] = [],
         testExampleFuncs: [TestFunctionGenerator] = []
     ) throws {
         self.swiftTypeName = swiftTypeName
         self.structure = structure
-        self.exampleGenerator = example
+        self.exampleGenerators = examples
         self.testExampleFuncs = testExampleFuncs
 
         (decls, resourceObjectGenerators) = try JSONAPIDocumentSwiftGen.swiftDecls(

--- a/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/StructDocumentSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/StructDocumentSwiftGen.swift
@@ -18,7 +18,7 @@ public struct StructDocumentSwiftGen: DocumentSwiftGenerator {
     public let decls: [Decl]
     public let swiftTypeName: String
     public let structGenerator: StructureSwiftGen
-    public let exampleGenerator: ExampleSwiftGen?
+    public let exampleGenerators: [ExampleSwiftGen]
     public let testExampleFuncs: [TestFunctionGenerator]
 
     public let swiftCodeDependencies: [SwiftGenerator] = []
@@ -27,12 +27,12 @@ public struct StructDocumentSwiftGen: DocumentSwiftGenerator {
         swiftTypeName: String,
         structure: DereferencedJSONSchema,
         allowPlaceholders: Bool = true,
-        example: ExampleSwiftGen? = nil,
+        examples: [ExampleSwiftGen] = [],
         testExampleFuncs: [TestFunctionGenerator] = []
     ) throws {
         self.swiftTypeName = swiftTypeName
         self.structure = structure
-        self.exampleGenerator = example
+        self.exampleGenerators = examples
         self.testExampleFuncs = testExampleFuncs
 
         let structGenerator = try StructureSwiftGen(

--- a/Sources/JSONAPISwiftGen/Swift Generators/ExampleSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/ExampleSwiftGen.swift
@@ -12,6 +12,9 @@ import JSONAPI
 /// A Generator that produces Swift code defining an OpenAPI example
 /// request/response body as a constant `Data`.
 public struct ExampleSwiftGen: SwiftGenerator {
+    /// The name of the property generated and stored as decl(s)
+    /// by this generator.
+    public let propertyName: String
     public let decls: [Decl]
 
     private let exampleAsDataSwiftString: String
@@ -29,6 +32,7 @@ public struct ExampleSwiftGen: SwiftGenerator {
     ///     - propertyName: The name of the constant the generated Swift code should
     ///         produce.
     public init(openAPIExample: AnyCodable, propertyName: String) throws {
+        self.propertyName = propertyName
         let encoder = JSONEncoder()
         let exampleData = try encoder.encode(openAPIExample)
         guard let exampleString = String(data: exampleData, encoding: .utf8) else {
@@ -41,9 +45,13 @@ public struct ExampleSwiftGen: SwiftGenerator {
 
         exampleAsDataSwiftString = "###\"\(exampleString)\"###.data(using: .utf8)!"
 
-        let decl = StaticDecl(PropDecl.var(propName: propertyName,
-                                swiftType: .rep(Data.self),
-                                DynamicValue(value: exampleAsDataSwiftString)))
+        let decl = StaticDecl(
+            PropDecl.var(
+                propName: propertyName,
+                swiftType: .rep(Data.self),
+                DynamicValue(value: exampleAsDataSwiftString)
+            )
+        )
 
         decls = [decl]
     }

--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/OpenAPIExampleParseTestSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/OpenAPIExampleParseTestSwiftGen.swift
@@ -32,7 +32,8 @@ public struct OpenAPIExampleParseTestSwiftGen: TestFunctionGenerator {
     public init(
         exampleDataPropName: String,
         bodyType: SwiftTypeRep,
-        exampleHttpStatusCode: OpenAPI.Response.StatusCode?
+        exampleHttpStatusCode: OpenAPI.Response.StatusCode?,
+        exampleName: String
     ) throws {
 
         let responseBodyDecl = PropDecl.let(
@@ -43,7 +44,7 @@ public struct OpenAPIExampleParseTestSwiftGen: TestFunctionGenerator {
 
         let context = TestFunctionLocalContext(
             contextPrefix: "test_example_parse",
-            slug: nil,
+            slug: exampleName,
             statusCode: exampleHttpStatusCode
         )
         testFunctionContext = context


### PR DESCRIPTION
Support for generating multiple example parse tests when multiple named examples are found for a response.