### PR TITLE
treat anyof as oneof for structure parsing type generation.

### DIFF
--- a/Sources/JSONAPISwiftGen/Swift Generators/ResourceObjectSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/ResourceObjectSwiftGen.swift
@@ -286,7 +286,7 @@ public struct ResourceObjectSwiftGen: JSONSchemaSwiftGenerator, ResourceTypeSwif
         let dependencies: [Decl]
 
         switch schema {
-        case .object, .one:
+        case .object, .one, .any:
             let structureGen = try StructureSwiftGen(
                 swiftTypeName: typeCased(name),
                 structure: schema,

--- a/Sources/JSONAPISwiftGen/Swift Generators/StructureSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/StructureSwiftGen.swift
@@ -51,7 +51,14 @@ public struct StructureSwiftGen: JSONSchemaSwiftGenerator {
                     rootConformances: rootConformances
                 )
             ]
-        case .one(of: let schemas, core: _):
+        // NOTE: This is not a great place to treat "anyOf" the same way as
+        //       "oneOf" but doing so might successfully parse a specific
+        //       subset of "anyOf"s: those where you can expect one of the
+        //       cases to succeed completely but just happen to have overlapping
+        //       success cases -- even then, you may end up with a Poly that
+        //       successfully parses fewer than all of an encoded resource because
+        //       of two applicable "anyOf" branches the less inclusive one came first.
+        case .one(of: let schemas, core: _), .any(of: schemas, core: _):
             let poly = try StructureSwiftGen.structure(
                 named: typeName,
                 forOneOf: schemas,

--- a/Sources/JSONAPISwiftGen/Swift Generators/StructureSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/StructureSwiftGen.swift
@@ -58,7 +58,7 @@ public struct StructureSwiftGen: JSONSchemaSwiftGenerator {
         //       success cases -- even then, you may end up with a Poly that
         //       successfully parses fewer than all of an encoded resource because
         //       of two applicable "anyOf" branches the less inclusive one came first.
-        case .one(of: let schemas, core: _), .any(of: schemas, core: _):
+        case .one(of: let schemas, core: _), .any(of: let schemas, core: _):
             let poly = try StructureSwiftGen.structure(
                 named: typeName,
                 forOneOf: schemas,

--- a/Tests/JSONAPISwiftGenTests/ResourceObjectSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/ResourceObjectSwiftGenTests.swift
@@ -71,6 +71,7 @@ class ResourceObjectSwiftGenTests: XCTestCase {
     }
 
     func test_polyAttribute() throws {
+        // test oneOf in simplest case
         let openAPIStructure = try testDecoder.decode(
             JSONSchema.self,
             from: """
@@ -111,6 +112,7 @@ class ResourceObjectSwiftGenTests: XCTestCase {
     }
 
     func test_polyAttribute2() throws {
+        // test oneOf with type & nullable at root
         let openAPIStructure = try testDecoder.decode(
             JSONSchema.self,
             from: """
@@ -157,6 +159,65 @@ class ResourceObjectSwiftGenTests: XCTestCase {
                                         ],
                                         "properties": {
                                             "built": {
+                                                "type": "boolean"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+            """.data(using: .utf8)!
+        ).dereferenced()!
+
+        let polyAttrSwiftGen = try ResourceObjectSwiftGen(structure: openAPIStructure)
+
+        XCTAssertEqual(polyAttrSwiftGen.resourceTypeName, "PolyThing")
+
+        print(polyAttrSwiftGen.swiftCode)
+    }
+
+    func test_polyAttribute3() throws {
+        // test anyOf as Poly
+        let openAPIStructure = try testDecoder.decode(
+            JSONSchema.self,
+            from: """
+            {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "enum": ["poly_thing"]},
+                    "id": {"type": "string"},
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "poly_property": {
+                                "type": "object",
+                                "nullable": true,
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "title": "Metadata 1",
+                                        "additionalProperties": true,
+                                        "nullable": true,
+                                        "properties": {
+                                            "title": {
+                                                "type": "string",
+                                                "description": "title"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "object",
+                                        "title": "Metadata 2",
+                                        "additionalProperties": true,
+                                        "properties": {
+                                            "title": {
+                                                "type": "string",
+                                                "description": "title"
+                                            },
+                                            "is_starred": {
                                                 "type": "boolean"
                                             }
                                         }

--- a/Tests/JSONAPISwiftGenTests/ResourceObjectSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/ResourceObjectSwiftGenTests.swift
@@ -109,6 +109,73 @@ class ResourceObjectSwiftGenTests: XCTestCase {
 
         print(polyAttrSwiftGen.swiftCode)
     }
+
+    func test_polyAttribute2() throws {
+        let openAPIStructure = try testDecoder.decode(
+            JSONSchema.self,
+            from: """
+            {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "enum": ["poly_thing"]},
+                    "id": {"type": "string"},
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "poly_property": {
+                                "type": "object",
+                                "nullable": true,
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "title": "Widget",
+                                        "additionalProperties": false,
+                                        "nullable": true,
+                                        "required": [
+                                            "prop"
+                                        ],
+                                        "properties": {
+                                            "prop": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "yes",
+                                                    "no"
+                                                ]
+                                            },
+                                            "reasoning": {
+                                                "type": "string",
+                                                "nullable": true
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "object",
+                                        "title": "Cog",
+                                        "additionalProperties": false,
+                                        "required": [
+                                            "built"
+                                        ],
+                                        "properties": {
+                                            "built": {
+                                                "type": "boolean"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+            """.data(using: .utf8)!
+        ).dereferenced()!
+
+        let polyAttrSwiftGen = try ResourceObjectSwiftGen(structure: openAPIStructure)
+
+        XCTAssertEqual(polyAttrSwiftGen.resourceTypeName, "PolyThing")
+
+        print(polyAttrSwiftGen.swiftCode)
+    }
 }
 
 enum TestPersonDescription: JSONAPI.ResourceObjectDescription {


### PR DESCRIPTION
This only affects Swift generation of `anyOf` schemas.