### PR TITLE
Switch to OpenAPIKit 3.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.3-xenial
-          - swift:5.3-bionic
-          - swift:5.3-focal
-          - swift:5.3-centos8
-          - swift:5.3-amazonlinux2
+          - swift:5.8-bionic
+          - swift:5.8-focal
+          - swift:5.8-jammy
+          - swift:5.8-amazonlinux2
+          - swift:5.9-focal
+          - swift:5.9-jammy
+          - swift:5.9-amazonlinux2
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.8-bionic
-          - swift:5.8-focal
-          - swift:5.8-jammy
-          - swift:5.8-amazonlinux2
           - swift:5.9-focal
           - swift:5.9-jammy
           - swift:5.9-amazonlinux2
@@ -25,14 +21,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run tests
-      run: swift test --enable-test-discovery
+      run: swift test
   osx:
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
-        with: { 'xcode-version': 'latest' }
+        with: 
+          xcode-version: latest
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run tests
-        run: swift test --enable-test-discovery
+        run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,151 +1,149 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Chalk",
-        "repositoryURL": "https://github.com/mxcl/Chalk.git",
-        "state": {
-          "branch": null,
-          "revision": "a7f58e47a08ca5a84f73acc4bcf6c2c19d990609",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "FileCheck",
-        "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
-        "state": {
-          "branch": null,
-          "revision": "f7c5f1a9479b33a876a6f5632ca2b92a7ce4b667",
-          "version": "0.2.6"
-        }
-      },
-      {
-        "package": "JSONAPI",
-        "repositoryURL": "https://github.com/mattpolzin/JSONAPI.git",
-        "state": {
-          "branch": null,
-          "revision": "661dfc3ffec1ba3a201fd067877da2f3c553f236",
-          "version": "5.1.0"
-        }
-      },
-      {
-        "package": "JSONAPIViz",
-        "repositoryURL": "https://github.com/mattpolzin/JSONAPIViz.git",
-        "state": {
-          "branch": null,
-          "revision": "407422e121c2d73f6dd262071df62481cb4016e9",
-          "version": "0.0.6"
-        }
-      },
-      {
-        "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
-        "state": {
-          "branch": "release/3_0",
-          "revision": "b069168ebd9bac3704beab3aadff07b589aadeb2",
-          "version": null
-        }
-      },
-      {
-        "package": "OpenAPIReflection",
-        "repositoryURL": "https://github.com/mattpolzin/OpenAPIReflection.git",
-        "state": {
-          "branch": "openapikit-3",
-          "revision": "64fbc8cb185175ad2f8709bf526e6bed38a469b4",
-          "version": null
-        }
-      },
-      {
-        "package": "Poly",
-        "repositoryURL": "https://github.com/mattpolzin/Poly.git",
-        "state": {
-          "branch": null,
-          "revision": "c108e9e0a2904134719b082f6c18d64406afc6db",
-          "version": "2.6.0"
-        }
-      },
-      {
-        "package": "Sampleable",
-        "repositoryURL": "https://github.com/mattpolzin/Sampleable.git",
-        "state": {
-          "branch": null,
-          "revision": "df44bf1a860481109dcf455e3c6daf0a0f1bc259",
-          "version": "2.1.0"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
-          "version": "1.1.4"
-        }
-      },
-      {
-        "package": "swift-format",
-        "repositoryURL": "https://github.com/apple/swift-format.git",
-        "state": {
-          "branch": null,
-          "revision": "fbfe1869527923dd9f9b2edac148baccfce0dce7",
-          "version": "508.0.1"
-        }
-      },
-      {
-        "package": "NonEmpty",
-        "repositoryURL": "https://github.com/pointfreeco/swift-nonempty.git",
-        "state": {
-          "branch": null,
-          "revision": "9ef8c4aea57b8da7fedd5303d29470ea2a00c08d",
-          "version": "0.2.2"
-        }
-      },
-      {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax",
-        "state": {
-          "branch": null,
-          "revision": "2c49d66d34dfd6f8130afdba889de77504b58ec0",
-          "version": "508.0.1"
-        }
-      },
-      {
-        "package": "swift-system",
-        "repositoryURL": "https://github.com/apple/swift-system.git",
-        "state": {
-          "branch": null,
-          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "swift-tools-support-core",
-        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
-        "state": {
-          "branch": null,
-          "revision": "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
-          "version": "0.6.1"
-        }
-      },
-      {
-        "package": "SwiftCheck",
-        "repositoryURL": "https://github.com/typelift/SwiftCheck.git",
-        "state": {
-          "branch": null,
-          "revision": "077c096c3ddfc38db223ac8e525ad16ffb987138",
-          "version": "0.12.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-          "version": "5.0.6"
-        }
+  "pins" : [
+    {
+      "identity" : "chalk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Chalk.git",
+      "state" : {
+        "revision" : "a7f58e47a08ca5a84f73acc4bcf6c2c19d990609",
+        "version" : "0.5.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "filecheck",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/llvm-swift/FileCheck.git",
+      "state" : {
+        "revision" : "f7c5f1a9479b33a876a6f5632ca2b92a7ce4b667",
+        "version" : "0.2.6"
+      }
+    },
+    {
+      "identity" : "jsonapi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/JSONAPI.git",
+      "state" : {
+        "revision" : "661dfc3ffec1ba3a201fd067877da2f3c553f236",
+        "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "jsonapiviz",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/JSONAPIViz.git",
+      "state" : {
+        "revision" : "407422e121c2d73f6dd262071df62481cb4016e9",
+        "version" : "0.0.6"
+      }
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
+      "state" : {
+        "revision" : "ae98338a8e660ae547b058ebb69c010e70b64e31",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "openapireflection",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIReflection.git",
+      "state" : {
+        "revision" : "aa9d56c75b913818c513a3b0a2cd716b8443e81e",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "poly",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/Poly.git",
+      "state" : {
+        "revision" : "c108e9e0a2904134719b082f6c18d64406afc6db",
+        "version" : "2.6.0"
+      }
+    },
+    {
+      "identity" : "sampleable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/Sampleable.git",
+      "state" : {
+        "revision" : "df44bf1a860481109dcf455e3c6daf0a0f1bc259",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-cmark.git",
+      "state" : {
+        "revision" : "f218e5d7691f78b55bfa39b367763f4612486c35",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-format",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-format.git",
+      "state" : {
+        "revision" : "83248b4fa37919f78ffbd4650946759bcc54c2b5",
+        "version" : "509.0.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "e4f95e2dc23097a1a9a1dfdfe3fe3ee44de77378",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-nonempty",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-nonempty.git",
+      "state" : {
+        "revision" : "9ef8c4aea57b8da7fedd5303d29470ea2a00c08d",
+        "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
+    },
+    {
+      "identity" : "swiftcheck",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/typelift/SwiftCheck.git",
+      "state" : {
+        "revision" : "077c096c3ddfc38db223ac8e525ad16ffb987138",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-format.git",
         "state": {
           "branch": null,
-          "revision": "5f184220d032a019a63df457cdea4b9c8241e911",
-          "version": "0.50700.1"
+          "revision": "fbfe1869527923dd9f9b2edac148baccfce0dce7",
+          "version": "508.0.1"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "72d3da66b085c2299dd287c2be3b92b5ebd226de",
-          "version": "0.50700.1"
+          "revision": "2c49d66d34dfd6f8130afdba889de77504b58ec0",
+          "version": "508.0.1"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "4f07be3dc201f6e2ee85b6942d0c220a16926811",
-          "version": "0.2.7"
+          "revision": "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
+          "version": "0.6.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mxcl/Chalk.git",
         "state": {
           "branch": null,
-          "revision": "9aa9f348b86db3cf6702a3e43c081ecec80cf3c7",
-          "version": "0.4.0"
+          "revision": "a7f58e47a08ca5a84f73acc4bcf6c2c19d990609",
+          "version": "0.5.0"
         }
       },
       {
@@ -15,17 +15,8 @@
         "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
         "state": {
           "branch": null,
-          "revision": "0dc8a5bff1a7f01e1d7bcc20c79e2127b2ea3eeb",
-          "version": "0.2.5"
-        }
-      },
-      {
-        "package": "FineJSON",
-        "repositoryURL": "https://github.com/omochi/FineJSON.git",
-        "state": {
-          "branch": null,
-          "revision": "05101709243cb66d80c92e645210a3b80cf4e17f",
-          "version": "1.14.0"
+          "revision": "f7c5f1a9479b33a876a6f5632ca2b92a7ce4b667",
+          "version": "0.2.6"
         }
       },
       {
@@ -33,8 +24,8 @@
         "repositoryURL": "https://github.com/mattpolzin/JSONAPI.git",
         "state": {
           "branch": null,
-          "revision": "717f3d610e87705adca2bb91a03fd4e92c433845",
-          "version": "5.0.1"
+          "revision": "661dfc3ffec1ba3a201fd067877da2f3c553f236",
+          "version": "5.1.0"
         }
       },
       {
@@ -50,18 +41,18 @@
         "package": "OpenAPIKit",
         "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
         "state": {
-          "branch": null,
-          "revision": "4e7f67551e26b0430297d7720a744df22ed7a018",
-          "version": "2.3.1"
+          "branch": "release/3_0",
+          "revision": "b069168ebd9bac3704beab3aadff07b589aadeb2",
+          "version": null
         }
       },
       {
         "package": "OpenAPIReflection",
         "repositoryURL": "https://github.com/mattpolzin/OpenAPIReflection.git",
         "state": {
-          "branch": null,
-          "revision": "2747214f17d17d4662c03d9cbe85e5e3307285ea",
-          "version": "1.0.0"
+          "branch": "openapikit-3",
+          "revision": "64fbc8cb185175ad2f8709bf526e6bed38a469b4",
+          "version": null
         }
       },
       {
@@ -69,17 +60,8 @@
         "repositoryURL": "https://github.com/mattpolzin/Poly.git",
         "state": {
           "branch": null,
-          "revision": "7dd2d0d3e6c0625f36f1b8306a90db12719240c8",
-          "version": "2.5.2"
-        }
-      },
-      {
-        "package": "RichJSONParser",
-        "repositoryURL": "https://github.com/omochi/RichJSONParser.git",
-        "state": {
-          "branch": null,
-          "revision": "263e2ecfe88d0500fa99e4cbc8c948529d335534",
-          "version": "3.0.0"
+          "revision": "c108e9e0a2904134719b082f6c18d64406afc6db",
+          "version": "2.6.0"
         }
       },
       {
@@ -96,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
-          "version": "0.3.2"
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
         }
       },
       {
@@ -105,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-format.git",
         "state": {
           "branch": null,
-          "revision": "12089179aa1668a2478b2b2111d98fa37f3531e3",
-          "version": "0.50300.0"
+          "revision": "5f184220d032a019a63df457cdea4b9c8241e911",
+          "version": "0.50700.1"
         }
       },
       {
@@ -123,8 +105,26 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+          "version": "0.50700.1"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
+        "state": {
+          "branch": null,
+          "revision": "4f07be3dc201f6e2ee85b6942d0c220a16926811",
+          "version": "0.2.7"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
-          "version": "4.0.4"
+          "revision": "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+          "version": "5.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/mattpolzin/Sampleable.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/JSONAPI.git", from: "5.0.0"),
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
+//        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", .commit("64568bf1599cefc275952d2b29c780d52a13b4f2")),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0"),
         .package(url: "https://github.com/typelift/SwiftCheck.git", .upToNextMinor(from: "0.12.0")),
         .package(url: "https://github.com/apple/swift-format.git", from: "0.50300.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", .branch("release/3_0")),
         .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", .branch("openapikit-3")),
         .package(url: "https://github.com/typelift/SwiftCheck.git", .upToNextMinor(from: "0.12.0")),
-        .package(url: "https://github.com/apple/swift-format.git", from: "0.50300.0"),
+        .package(url: "https://github.com/apple/swift-format.git", from: "508.0.1"),
         .package(name: "NonEmpty", url: "https://github.com/pointfreeco/swift-nonempty.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/mattpolzin/JSONAPIViz.git", .exact("0.0.6"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "JSONAPI-OpenAPI",
     platforms: [
-        .macOS(.v10_11),
+        .macOS(.v12),
     ],
     products: [
         .library(
@@ -21,9 +21,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/mattpolzin/Sampleable.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/JSONAPI.git", from: "5.0.0"),
-//        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.0.0"),
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", .commit("64568bf1599cefc275952d2b29c780d52a13b4f2")),
-        .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "1.0.0"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", .branch("release/3_0")),
+        .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", .branch("openapikit-3")),
         .package(url: "https://github.com/typelift/SwiftCheck.git", .upToNextMinor(from: "0.12.0")),
         .package(url: "https://github.com/apple/swift-format.git", from: "0.50300.0"),
         .package(name: "NonEmpty", url: "https://github.com/pointfreeco/swift-nonempty.git", .upToNextMinor(from: "0.2.0")),
@@ -34,8 +33,8 @@ let package = Package(
             name: "JSONAPIOpenAPI",
             dependencies: [
                 "JSONAPI",
-                "OpenAPIKit",
-                "OpenAPIReflection",
+                .product(name: "OpenAPIKit30", package: "OpenAPIKit"),
+                .product(name: "OpenAPIReflection30", package: "OpenAPIReflection"),
                 "Sampleable"
             ]
         ),
@@ -52,7 +51,7 @@ let package = Package(
             name: "JSONAPISwiftGen",
             dependencies: [
                 "JSONAPI",
-                "OpenAPIKit",
+                .product(name: "OpenAPIKit30", package: "OpenAPIKit"),
                 .product(name: "SwiftFormat", package: "swift-format"),
                 .product(name: "SwiftFormatConfiguration", package: "swift-format"),
                 .product(name: "NonEmpty", package: "NonEmpty")

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.8
 
 import PackageDescription
 
@@ -21,12 +21,12 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/mattpolzin/Sampleable.git", from: "2.0.0"),
         .package(url: "https://github.com/mattpolzin/JSONAPI.git", from: "5.0.0"),
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", .branch("release/3_0")),
-        .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", .branch("openapikit-3")),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIReflection.git", from: "2.0.0"),
         .package(url: "https://github.com/typelift/SwiftCheck.git", .upToNextMinor(from: "0.12.0")),
-        .package(url: "https://github.com/apple/swift-format.git", from: "508.0.1"),
-        .package(name: "NonEmpty", url: "https://github.com/pointfreeco/swift-nonempty.git", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/mattpolzin/JSONAPIViz.git", .exact("0.0.6"))
+        .package(url: "https://github.com/apple/swift-format.git", from: "509.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-nonempty.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/mattpolzin/JSONAPIViz.git", exact: "0.0.6")
     ],
     targets: [
         .target(
@@ -54,7 +54,7 @@ let package = Package(
                 .product(name: "OpenAPIKit30", package: "OpenAPIKit"),
                 .product(name: "SwiftFormat", package: "swift-format"),
                 .product(name: "SwiftFormatConfiguration", package: "swift-format"),
-                .product(name: "NonEmpty", package: "NonEmpty")
+                .product(name: "NonEmpty", package: "swift-nonempty")
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # JSONAPI+OpenAPI
-[![MIT license](http://img.shields.io/badge/license-MIT-lightgrey.svg)](http://opensource.org/licenses/MIT) [![Swift 5.3](http://img.shields.io/badge/Swift-5.3-blue.svg)](https://swift.org) [![Build Status](https://app.bitrise.io/app/2ae0b5578e1905b8/status.svg?token=T8UAUN08e1_GnYk1z3P98g&branch=main)](https://app.bitrise.io/app/2ae0b5578e1905b8)
+[![MIT license](http://img.shields.io/badge/license-MIT-lightgrey.svg)](http://opensource.org/licenses/MIT) [![Swift 5.8](http://img.shields.io/badge/Swift-5.8-blue.svg)](https://swift.org) [![Build Status](https://app.bitrise.io/app/2ae0b5578e1905b8/status.svg?token=T8UAUN08e1_GnYk1z3P98g&branch=main)](https://app.bitrise.io/app/2ae0b5578e1905b8)
 
 See parent project: https://github.com/mattpolzin/JSONAPI
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # JSONAPI+OpenAPI
-[![MIT license](http://img.shields.io/badge/license-MIT-lightgrey.svg)](http://opensource.org/licenses/MIT) [![Swift 5.8](http://img.shields.io/badge/Swift-5.8-blue.svg)](https://swift.org) [![Build Status](https://app.bitrise.io/app/2ae0b5578e1905b8/status.svg?token=T8UAUN08e1_GnYk1z3P98g&branch=main)](https://app.bitrise.io/app/2ae0b5578e1905b8)
+[![MIT license](http://img.shields.io/badge/license-MIT-lightgrey.svg)](http://opensource.org/licenses/MIT) [![Swift 5.9](http://img.shields.io/badge/Swift-5.9-blue.svg)](https://swift.org) [![Build Status](https://app.bitrise.io/app/2ae0b5578e1905b8/status.svg?token=T8UAUN08e1_GnYk1z3P98g&branch=main)](https://app.bitrise.io/app/2ae0b5578e1905b8)
 
 See parent project: https://github.com/mattpolzin/JSONAPI
 
@@ -7,7 +7,7 @@ The `JSONAPIOpenAPI` framework adds the ability to generate OpenAPI compliant JS
 
 There is experimental support for generating `JSONAPI` Swift code from OpenAPI documentation in the JSONAPISwiftGen module. There is no formal documentation for this functionality, but it is an area of interest of mine. Reach out to me directly if you would like to know more.
 
-See the Open API Spec here: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md
+See the Open API Spec here: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md
 
 *This library has many loose ends and very little documentation. The documentation will grow as the framework becomes more complete.*
 

--- a/Sources/JSONAPIOpenAPI/Exports.swift
+++ b/Sources/JSONAPIOpenAPI/Exports.swift
@@ -6,5 +6,5 @@
 //
 
 @_exported import JSONAPI
-@_exported import OpenAPIKit
-@_exported import OpenAPIReflection
+@_exported import OpenAPIKit30
+@_exported import OpenAPIReflection30

--- a/Sources/JSONAPIOpenAPI/JSONAPI/JSONAPIAttribute+OpenAPI.swift
+++ b/Sources/JSONAPIOpenAPI/JSONAPI/JSONAPIAttribute+OpenAPI.swift
@@ -6,8 +6,8 @@
 //
 
 import JSONAPI
-import OpenAPIKit
-import OpenAPIReflection
+import OpenAPIKit30
+import OpenAPIReflection30
 import Foundation
 import Sampleable
 
@@ -76,10 +76,10 @@ extension Attribute: OpenAPIAttributeType where RawValue: Sampleable, RawValue: 
         // If the RawValue is not required, we actually consider it
         // nullable. To be not required is for the Attribute itself
         // to be optional.
-        if try !OpenAPIReflection.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).required {
-            return try OpenAPIReflection.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).requiredSchemaObject().nullableSchemaObject()
+        if try !OpenAPIReflection30.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).required {
+            return try OpenAPIReflection30.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).requiredSchemaObject().nullableSchemaObject()
         }
-        return try OpenAPIReflection.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder)
+        return try OpenAPIReflection30.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder)
     }
 }
 
@@ -137,9 +137,9 @@ extension TransformedAttribute: OpenAPIAttributeType where RawValue: Sampleable,
         // If the RawValue is not required, we actually consider it
         // nullable. To be not required is for the Attribute itself
         // to be optional.
-        if try !OpenAPIReflection.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).required {
-            return try OpenAPIReflection.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).requiredSchemaObject().nullableSchemaObject()
+        if try !OpenAPIReflection30.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).required {
+            return try OpenAPIReflection30.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder).requiredSchemaObject().nullableSchemaObject()
         }
-        return try OpenAPIReflection.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder)
+        return try OpenAPIReflection30.genericOpenAPISchemaGuess(for: RawValue.sample, using: encoder)
     }
 }

--- a/Sources/JSONAPIOpenAPI/JSONAPI/JSONAPIInclude+OpenAPI.swift
+++ b/Sources/JSONAPIOpenAPI/JSONAPI/JSONAPIInclude+OpenAPI.swift
@@ -6,8 +6,8 @@
 //
 
 import JSONAPI
-import OpenAPIKit
-import OpenAPIReflection
+import OpenAPIKit30
+import OpenAPIReflection30
 import Foundation
 
 extension Includes: OpenAPIEncodedSchemaType where I: OpenAPIEncodedSchemaType {

--- a/Sources/JSONAPIOpenAPI/JSONAPI/JSONAPITypes+OpenAPI.swift
+++ b/Sources/JSONAPIOpenAPI/JSONAPI/JSONAPITypes+OpenAPI.swift
@@ -6,8 +6,8 @@
 //
 
 import JSONAPI
-import OpenAPIKit
-import OpenAPIReflection
+import OpenAPIKit30
+import OpenAPIReflection30
 import Foundation
 import Sampleable
 
@@ -21,7 +21,7 @@ extension Optional: Wrapper {}
 
 extension RelationshipType {
 	static func relationshipNode(nullable: Bool, jsonType: String) -> JSONSchema {
-		let propertiesDict: [String: JSONSchema] = [
+		let propertiesDict: OrderedDictionary<String, JSONSchema> = [
 			"id": .string,
 			"type": .string(
                 allowedValues: [.init(jsonType)]
@@ -95,7 +95,7 @@ extension ResourceObject: OpenAPIEncodedSchemaType where Description.Attributes:
 
 		let relationshipsProperty = relationshipsNode.map { ("relationships", $0) }
 
-		let propertiesDict = Dictionary([
+		let propertiesDict = OrderedDictionary([
 			idProperty,
 			typeProperty,
 			attributesProperty,
@@ -194,7 +194,7 @@ extension Document.SuccessDocument: OpenAPIEncodedSchemaType where PrimaryResour
 
         let includeProperty = includeNode.map { ("included", $0) }
 
-        let propertiesDict = Dictionary([
+        let propertiesDict = OrderedDictionary([
             primaryDataProperty,
             includeProperty
             ].compactMap { $0 }) { _, value in value }

--- a/Sources/JSONAPIOpenAPI/Sampleable/Include+Sampleable.swift
+++ b/Sources/JSONAPIOpenAPI/Sampleable/Include+Sampleable.swift
@@ -7,6 +7,7 @@
 
 import JSONAPI
 import Sampleable
+import Poly
 
 extension Includes: Sampleable, AbstractSampleable where I: Sampleable {
 	public static var sample: Includes<I> {

--- a/Sources/JSONAPISwiftGen/ResourceObjectSwiftGenCollection.swift
+++ b/Sources/JSONAPISwiftGen/ResourceObjectSwiftGenCollection.swift
@@ -5,7 +5,7 @@
 //  Created by Mathew Polzin on 1/7/20.
 //
 
-import OpenAPIKit
+import OpenAPIKit30
 
 public struct ResourceObjectSwiftGenCollection {
     public let resourceObjectGenerators: [ResourceObjectSwiftGen]

--- a/Sources/JSONAPISwiftGen/ResourceObjectSwiftGenCollection.swift
+++ b/Sources/JSONAPISwiftGen/ResourceObjectSwiftGenCollection.swift
@@ -114,7 +114,7 @@ func documents(
                 print("-- While parsing the HTTP \(statusCode.rawValue) response document for \(httpVerb.rawValue) at \(path.rawValue)")
                 print("===")
             }
-        } else if let examples = jsonResponse.examples?.mapValues({ $0.value.b }) {
+        } else if let examples = jsonResponse.examples?.mapValues({ $0.value?.b }) {
             // if there are multiple examples, we simply generate tests for each named example
             // because we don't yet support request-based testing for named examples.
 

--- a/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/JSONAPIDocumentSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/JSONAPIDocumentSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 /// Only handles success (Data) case for JSON:API Document.

--- a/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/StructDocumentSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Document Generators/StructDocumentSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 /// Creates a request or response document (no difference encoded in this

--- a/Sources/JSONAPISwiftGen/Swift Generators/ExampleSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/ExampleSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import struct OpenAPIKit.AnyCodable
+import struct OpenAPIKit30.AnyCodable
 import JSONAPI
 
 /// A Generator that produces Swift code defining an OpenAPI example

--- a/Sources/JSONAPISwiftGen/Swift Generators/ResourceObjectStubSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/ResourceObjectStubSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 public struct ResourceObjectStubSwiftGen: ResourceTypeSwiftGenerator {

--- a/Sources/JSONAPISwiftGen/Swift Generators/ResourceObjectSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/ResourceObjectSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 public protocol ResourceTypeSwiftGenerator: SwiftTypeGenerator {
@@ -334,7 +334,7 @@ public struct ResourceObjectSwiftGen: JSONSchemaSwiftGenerator, ResourceTypeSwif
             return (relatives: [], relationshipsDecl: Typealias(alias: .init(relationshipTypeName), existingType: .init(NoRelationships.self)))
         }
 
-        let relationshipDecls: [(relative: Relative, decl: Decl)] = try relationshipsContextB
+        let relationshipDecls: [(relative: Relative, typeNameDeclCode: Decl)] = try relationshipsContextB
             .properties
             .sorted { $0.key < $1.key }
             .map { keyValue in
@@ -361,7 +361,7 @@ public struct ResourceObjectSwiftGen: JSONSchemaSwiftGenerator, ResourceTypeSwif
         )
 
         let relationshipsAndCodingKeys = relationshipDecls
-            .map { $0.decl }
+            .map { $0.typeNameDeclCode }
             + (hasRelationships ? [codingKeyDecl] : []) // only include CodingKeys if non-zero count of relationships
 
         let relatives = relationshipDecls.map { $0.relative }

--- a/Sources/JSONAPISwiftGen/Swift Generators/StructureSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/StructureSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 
 /// Given some JSON Schema, attempt to generate Swift code for
 /// a `struct` that is capable of parsing data adhering to the schema.

--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/APIRequestTestSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/APIRequestTestSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 /// A Generator that produces Swift code defining a function that

--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/OpenAPIExampleParseTestSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/OpenAPIExampleParseTestSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 
 /// A Generator that produces Swift code defining a test function
 /// based on a provided OpenAPI example. It will verify the example

--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/OpenAPIExampleRequestTestSwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/OpenAPIExampleRequestTestSwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 
 public extension OpenAPI.Parameter {
     /// Map from a Parameter's name to that Parameter's string-encoded value

--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/RequestTestProperties.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/RequestTestProperties.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 
 extension OpenAPIExampleRequestTestSwiftGen {
 

--- a/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/TestFunctionName.swift
+++ b/Sources/JSONAPISwiftGen/Swift Generators/Test Generators/TestFunctionName.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 
 /// A type that holds all information necessary to
 /// determine

--- a/Sources/JSONAPISwiftGen/SwiftDecls.swift
+++ b/Sources/JSONAPISwiftGen/SwiftDecls.swift
@@ -1,5 +1,5 @@
 
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 public protocol DefValue: SwiftCodeRepresentable {

--- a/Sources/JSONAPISwiftGen/SwiftGen.swift
+++ b/Sources/JSONAPISwiftGen/SwiftGen.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPI
 
 /// A relatively ad-hoc list of names that if used for generated types in the

--- a/Sources/JSONAPISwiftGen/SwiftTypes.swift
+++ b/Sources/JSONAPISwiftGen/SwiftTypes.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import JSONAPI
-import struct OpenAPIKit.AnyCodable
+import struct OpenAPIKit30.AnyCodable
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Tests/JSONAPIOpenAPITests/JSONAPIAttributeOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIAttributeOpenAPITests.swift
@@ -22,8 +22,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -43,8 +44,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -65,8 +67,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -86,8 +89,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -111,8 +115,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -141,8 +146,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -172,8 +178,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -202,8 +209,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -235,8 +243,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -258,8 +267,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -282,8 +292,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -305,8 +316,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -338,8 +350,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -361,8 +374,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -385,8 +399,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -408,8 +423,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -435,8 +451,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -458,8 +475,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -482,8 +500,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -505,8 +524,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -535,8 +555,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -558,8 +579,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -582,8 +604,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -605,8 +628,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -648,8 +672,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .string(.date))
+    let schema = node?.value
 
-		guard case .string(let contextA, let stringContext)? = node else {
+		guard case .string(let contextA, let stringContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -684,8 +709,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.date))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -723,8 +749,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .string(.dateTime))
+    let schema = node?.value
 
-		guard case .string(let contextA, let stringContext)? = node else {
+		guard case .string(let contextA, let stringContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -760,8 +787,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.dateTime))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -794,8 +822,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 			XCTAssertTrue(node?.required ?? false)
 			XCTAssertEqual(node?.jsonTypeFormat, .string(.dateTime))
+    let schema = node?.value
 
-			guard case .string(let contextA, let stringContext)? = node else {
+			guard case .string(let contextA, let stringContext)? = schema else {
 				XCTFail("Expected string Node")
 				return
 			}
@@ -827,8 +856,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 			XCTAssertTrue(node.required)
 			XCTAssertEqual(node.jsonTypeFormat, .string(.dateTime))
+    let schema = node.value
 
-			guard case .string(let contextA, let stringContext) = node else {
+			guard case .string(let contextA, let stringContext) = schema else {
 				XCTFail("Expected string Node")
 				return
 			}
@@ -862,8 +892,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -894,8 +925,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -939,8 +971,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -968,8 +1001,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -998,8 +1032,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node?.required ?? true)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -1027,8 +1062,9 @@ extension JSONAPIAttributeOpenAPITests {
 
 		XCTAssertFalse(node?.required ?? true)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}

--- a/Tests/JSONAPIOpenAPITests/JSONAPIAttributeOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIAttributeOpenAPITests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import JSONAPI
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPIOpenAPI
 import SwiftCheck
 import Sampleable

--- a/Tests/JSONAPIOpenAPITests/JSONAPIDocumentOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIDocumentOpenAPITests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import SwiftCheck
 import JSONAPI
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPIOpenAPI
 import Sampleable
 

--- a/Tests/JSONAPIOpenAPITests/JSONAPIDocumentOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIDocumentOpenAPITests.swift
@@ -28,8 +28,9 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected JSON Document to be an Object Node")
 			return
 		}
@@ -43,7 +44,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertEqual(Set(objectContext1.requiredProperties), Set(["data"]))
 		XCTAssertEqual(Set(objectContext1.properties.keys), Set(["data"]))
 
-		guard case let .object(contextB, objectContext2)? = objectContext1.properties["data"] else {
+		guard case let .object(contextB, objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected Data field of JSON Document to be an Object Node")
 			return
 		}
@@ -78,8 +79,9 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected JSON Document to be an Object Node")
 			return
 		}
@@ -93,7 +95,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertEqual(Set(objectContext1.requiredProperties), Set(["data"]))
 		XCTAssertEqual(Set(objectContext1.properties.keys), Set(["data"]))
 
-		guard case let .array(contextB, arrayContext)? = objectContext1.properties["data"] else {
+		guard case let .array(contextB, arrayContext)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected Data field of JSON Document to be an Array Node")
 			return
 		}
@@ -105,7 +107,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertFalse(arrayContext.uniqueItems)
 		XCTAssertEqual(arrayContext.minItems, 0)
 
-		guard case let .object(contextC, objectContext2)? = arrayContext.items else {
+		guard case let .object(contextC, objectContext2)? = arrayContext.items?.value else {
 			XCTFail("Expected Items of Array under Data to be an Object Node")
 			return
 		}
@@ -139,8 +141,9 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected JSON Document to be an Object Node")
 			return
 		}
@@ -154,7 +157,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertEqual(Set(objectContext1.requiredProperties), Set(["data", "included"]))
 		XCTAssertEqual(Set(objectContext1.properties.keys), Set(["data", "included"]))
 
-		guard case let .object(contextB, objectContext2)? = objectContext1.properties["data"] else {
+		guard case let .object(contextB, objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected Data field of JSON Document to be an Object Node")
 			return
 		}
@@ -173,7 +176,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 											 allowedValues: [.init("test")]),
 									   .init()))
 
-		guard case let .array(contextC, arrayContext)? = objectContext1.properties["included"] else {
+		guard case let .array(contextC, arrayContext)? = objectContext1.properties["included"]?.value else {
 			XCTFail("Expected Includes field of JSON Document to be an Array Node")
 			return
 		}
@@ -185,7 +188,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertTrue(arrayContext.uniqueItems)
 		XCTAssertEqual(arrayContext.minItems, 0)
 
-        guard case let .object(contextD, objectContext3)? = arrayContext.items else {
+        guard case let .object(contextD, objectContext3)? = arrayContext.items?.value else {
 			XCTFail("Expected Items of Array under Data to be an Object Node")
 			return
 		}
@@ -219,8 +222,9 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected JSON Document to be an Object Node")
 			return
 		}
@@ -234,7 +238,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertEqual(Set(objectContext1.requiredProperties), Set(["data", "included"]))
 		XCTAssertEqual(Set(objectContext1.properties.keys), Set(["data", "included"]))
 
-		guard case let .object(contextB, objectContext2)? = objectContext1.properties["data"] else {
+		guard case let .object(contextB, objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected Data field of JSON Document to be an Object Node")
 			return
 		}
@@ -253,7 +257,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 											 allowedValues: [.init("test")]),
 									   .init()))
 
-		guard case let .array(contextC, arrayContext)? = objectContext1.properties["included"] else {
+		guard case let .array(contextC, arrayContext)? = objectContext1.properties["included"]?.value else {
 			XCTFail("Expected Includes field of JSON Document to be an Array Node")
 			return
 		}
@@ -265,14 +269,14 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 		XCTAssertTrue(arrayContext.uniqueItems)
 		XCTAssertEqual(arrayContext.minItems, 0)
 
-		guard case let .one(of: includeNodes, _)? = arrayContext.items else {
+		guard case let .one(of: includeNodes, _)? = arrayContext.items?.value else {
 			XCTFail("Expected Included to contain multiple types of items.")
 			return
 		}
 
 		XCTAssertEqual(includeNodes.count, 2)
 
-		guard case let .object(contextD, objectContext3) = includeNodes[0] else {
+		guard case let .object(contextD, objectContext3) = includeNodes[0].value else {
 			XCTFail("Expected Items of OneOf under Array under Data to be an Object Node")
 			return
 		}
@@ -291,7 +295,7 @@ class JSONAPIDocumentOpenAPITests: XCTestCase {
 											 allowedValues: [.init("test")]),
 									   .init()))
 
-		guard case let .object(contextE, objectContext4) = includeNodes[1] else {
+		guard case let .object(contextE, objectContext4) = includeNodes[1].value else {
 			XCTFail("Expected Items of OneOf under Array under Data to be an Object Node")
 			return
 		}

--- a/Tests/JSONAPIOpenAPITests/JSONAPIEntityOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIEntityOpenAPITests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import JSONAPI
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPIOpenAPI
 import Sampleable
 

--- a/Tests/JSONAPIOpenAPITests/JSONAPIEntityOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIEntityOpenAPITests.swift
@@ -17,8 +17,9 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected Object node")
 			return
 		}
@@ -61,8 +62,9 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected Object node")
 			return
 		}
@@ -105,8 +107,9 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected Object node")
 			return
 		}
@@ -150,7 +153,7 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
 		XCTAssertTrue(attributesNode?.required ?? false)
 		XCTAssertEqual(attributesNode?.jsonTypeFormat, .object(.generic))
 
-		guard case let .object(contextB, attributesContext)? = attributesNode else {
+		guard case let .object(contextB, attributesContext)? = attributesNode?.value else {
 			XCTFail("Expected Object node for attributes")
 			return
 		}
@@ -248,8 +251,9 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case let .object(contextA, objectContext1) = node else {
+		guard case let .object(contextA, objectContext1) = schema else {
 			XCTFail("Expected Object node")
 			return
 		}
@@ -295,7 +299,7 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
 		XCTAssertTrue(relationshipsNode?.required ?? false)
 		XCTAssertEqual(relationshipsNode?.jsonTypeFormat, .object(.generic))
 
-		guard case let .object(contextB, relationshipsContext)? = relationshipsNode else {
+		guard case let .object(contextB, relationshipsContext)? = relationshipsNode?.value else {
 			XCTFail("Expected Object node for relationships")
 			return
 		}
@@ -316,28 +320,28 @@ class JSONAPIEntityOpenAPITests: XCTestCase {
             Set(["toOne", "optionalTooOne", "nullableToOne", "nullableOptionalToOne", "toMany", "optionalToMany"])
         )
 
-        let pointerDataProperties: [String: JSONSchema] = [
+        let pointerDataProperties: OrderedDictionary<String, JSONSchema> = [
             "id": .string,
             "type": .string(
                 allowedValues: [.init(TestType1.jsonType)]
             )
         ]
 
-        let pointerProperties: [String: JSONSchema] = [
+        let pointerProperties: OrderedDictionary<String, JSONSchema> = [
             "data": .object(
                 nullable: false,
                 properties: pointerDataProperties
             )
         ]
 
-        let nullablePointerProperties: [String: JSONSchema] = [
+        let nullablePointerProperties: OrderedDictionary<String, JSONSchema> = [
             "data": .object(
                 nullable: true,
                 properties: pointerDataProperties
             )
         ]
 
-        let manyPointerProperties: [String: JSONSchema] = [
+        let manyPointerProperties: OrderedDictionary<String, JSONSchema> = [
             "data": .array(
                 items: .object(
                     nullable: false,

--- a/Tests/JSONAPIOpenAPITests/JSONAPIRelationshipsOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIRelationshipsOpenAPITests.swift
@@ -8,7 +8,7 @@
 import Foundation
 import XCTest
 import JSONAPI
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPITesting
 import JSONAPIOpenAPI
 

--- a/Tests/JSONAPIOpenAPITests/JSONAPIRelationshipsOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPIRelationshipsOpenAPITests.swift
@@ -19,8 +19,9 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case .object(let contextA, let objectContext1) = node else {
+		guard case .object(let contextA, let objectContext1) = schema else {
 			XCTFail("Expected object Node")
 			return
 		}
@@ -37,7 +38,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 		XCTAssertNil(objectContext1.additionalProperties)
 		XCTAssertEqual(Array(objectContext1.properties.keys), ["data"])
 
-		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"] else {
+		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected object node within properties")
 			return
 		}
@@ -56,8 +57,9 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case .object(let contextA, let objectContext1) = node else {
+		guard case .object(let contextA, let objectContext1) = schema else {
 			XCTFail("Expected object Node")
 			return
 		}
@@ -74,7 +76,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 		XCTAssertNil(objectContext1.additionalProperties)
 		XCTAssertEqual(Array(objectContext1.properties.keys), ["data"])
 
-		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"] else {
+		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected object node within properties")
 			return
 		}
@@ -98,8 +100,9 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case .object(let contextA, let objectContext1) = node else {
+		guard case .object(let contextA, let objectContext1) = schema else {
 			XCTFail("Expected object Node")
 			return
 		}
@@ -116,7 +119,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 		XCTAssertNil(objectContext1.additionalProperties)
 		XCTAssertEqual(Array(objectContext1.properties.keys), ["data"])
 
-		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"] else {
+		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected object node within properties")
 			return
 		}
@@ -140,8 +143,9 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case .object(let contextA, let objectContext1) = node else {
+		guard case .object(let contextA, let objectContext1) = schema else {
 			XCTFail("Expected object Node")
 			return
 		}
@@ -158,7 +162,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 		XCTAssertNil(objectContext1.additionalProperties)
 		XCTAssertEqual(Array(objectContext1.properties.keys), ["data"])
 
-		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"] else {
+		guard case .object(let contextB, let objectContext2)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected object node within properties")
 			return
 		}
@@ -182,8 +186,9 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case .object(let contextA, let objectContext1) = node else {
+		guard case .object(let contextA, let objectContext1) = schema else {
 			XCTFail("Expected object Node")
 			return
 		}
@@ -200,7 +205,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 		XCTAssertNil(objectContext1.additionalProperties)
 		XCTAssertEqual(Array(objectContext1.properties.keys), ["data"])
 
-		guard case .array(let contextB, let arrayContext)? = objectContext1.properties["data"] else {
+		guard case .array(let contextB, let arrayContext)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected array node within properties")
 			return
 		}
@@ -214,7 +219,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
             )
         )
 
-		guard case .object(let contextC, let objectContext2)? = arrayContext.items else {
+		guard case .object(let contextC, let objectContext2)? = arrayContext.items?.value else {
 			XCTFail("Expected object node within items")
 			return
 		}
@@ -238,8 +243,9 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .object(.generic))
+    let schema = node.value
 
-		guard case .object(let contextA, let objectContext1) = node else {
+		guard case .object(let contextA, let objectContext1) = schema else {
 			XCTFail("Expected object Node")
 			return
 		}
@@ -256,7 +262,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
 		XCTAssertNil(objectContext1.additionalProperties)
 		XCTAssertEqual(Array(objectContext1.properties.keys), ["data"])
 
-		guard case .array(let contextB, let arrayContext)? = objectContext1.properties["data"] else {
+		guard case .array(let contextB, let arrayContext)? = objectContext1.properties["data"]?.value else {
 			XCTFail("Expected array node within properties")
 			return
 		}
@@ -270,7 +276,7 @@ class JSONAPIRelationshipsOpenAPITests: XCTestCase {
             )
         )
 
-		guard case .object(let contextC, let objectContext2)? = arrayContext.items else {
+		guard case .object(let contextC, let objectContext2)? = arrayContext.items?.value else {
 			XCTFail("Expected object node within items")
 			return
 		}

--- a/Tests/JSONAPIOpenAPITests/JSONAPITransformedAttributeOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPITransformedAttributeOpenAPITests.swift
@@ -23,8 +23,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -44,8 +45,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -66,8 +68,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -87,8 +90,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .boolean(.generic))
+    let schema = node.value
 
-		guard case .boolean(let contextA) = node else {
+		guard case .boolean(let contextA) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -112,8 +116,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -143,8 +148,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -175,8 +181,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -206,8 +213,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .array(.generic))
+    let schema = node.value
 
-		guard case .array(let contextA, let arrayContext) = node else {
+		guard case .array(let contextA, let arrayContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -241,8 +249,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -264,8 +273,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -288,8 +298,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -311,8 +322,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -344,8 +356,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -367,8 +380,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -391,8 +405,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -414,8 +429,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .integer(.generic))
+    let schema = node.value
 
-		guard case .integer(let contextA, let intContext) = node else {
+		guard case .integer(let contextA, let intContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -441,8 +457,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -464,8 +481,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -488,8 +506,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -511,8 +530,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -541,8 +561,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -564,8 +585,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -588,8 +610,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -611,8 +634,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.generic))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -654,8 +678,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .string(.date))
+    let schema = node?.value
 
-		guard case .string(let contextA, let stringContext)? = node else {
+		guard case .string(let contextA, let stringContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -691,8 +716,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.date))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -730,8 +756,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .string(.dateTime))
+    let schema = node?.value
 
-		guard case .string(let contextA, let stringContext)? = node else {
+		guard case .string(let contextA, let stringContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -767,8 +794,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .string(.dateTime))
+    let schema = node.value
 
-		guard case .string(let contextA, let stringContext) = node else {
+		guard case .string(let contextA, let stringContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -801,8 +829,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 			XCTAssertTrue(node?.required ?? false)
 			XCTAssertEqual(node?.jsonTypeFormat, .string(.dateTime))
+    let schema = node?.value
 
-			guard case .string(let contextA, let stringContext)? = node else {
+			guard case .string(let contextA, let stringContext)? = schema else {
 				XCTFail("Expected string Node")
 				return
 			}
@@ -834,8 +863,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 			XCTAssertTrue(node.required)
 			XCTAssertEqual(node.jsonTypeFormat, .string(.dateTime))
+    let schema = node.value
 
-			guard case .string(let contextA, let stringContext) = node else {
+			guard case .string(let contextA, let stringContext) = schema else {
 				XCTFail("Expected string Node")
 				return
 			}
@@ -869,8 +899,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -901,8 +932,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -946,8 +978,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node.required)
 		XCTAssertEqual(node.jsonTypeFormat, .number(.double))
+    let schema = node.value
 
-		guard case .number(let contextA, let numberContext) = node else {
+		guard case .number(let contextA, let numberContext) = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -975,8 +1008,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertTrue(node?.required ?? false)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -1005,8 +1039,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node?.required ?? true)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}
@@ -1034,8 +1069,9 @@ extension JSONAPITransformedAttributeOpenAPITests {
 
 		XCTAssertFalse(node?.required ?? true)
 		XCTAssertEqual(node?.jsonTypeFormat, .number(.double))
+    let schema = node?.value
 
-		guard case .number(let contextA, let numberContext)? = node else {
+		guard case .number(let contextA, let numberContext)? = schema else {
 			XCTFail("Expected string Node")
 			return
 		}

--- a/Tests/JSONAPIOpenAPITests/JSONAPITransformedAttributeOpenAPITests.swift
+++ b/Tests/JSONAPIOpenAPITests/JSONAPITransformedAttributeOpenAPITests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import JSONAPI
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPIOpenAPI
 import SwiftCheck
 

--- a/Tests/JSONAPISwiftGenTests/APIRequestTestSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/APIRequestTestSwiftGenTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import JSONAPI
 import JSONAPITesting
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPISwiftGen
 
 import Foundation

--- a/Tests/JSONAPISwiftGenTests/OpenAPIExampleRequestTestSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/OpenAPIExampleRequestTestSwiftGenTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPISwiftGen
 
 final class OpenAPIExampleRequestTestSwiftGenTests: XCTestCase {

--- a/Tests/JSONAPISwiftGenTests/ResourceObjectSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/ResourceObjectSwiftGenTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import JSONAPISwiftGen
 import JSONAPI
 import Sampleable
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPIOpenAPI
 
 let testEncoder = JSONEncoder()

--- a/Tests/JSONAPISwiftGenTests/SchemaSwiftTypeGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/SchemaSwiftTypeGenTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import XCTest
-import OpenAPIKit
+import OpenAPIKit30
 @testable import JSONAPISwiftGen
 
 class SchemaSwiftTypeGenTests: XCTestCase {

--- a/Tests/JSONAPISwiftGenTests/StructureSwiftGenTests.swift
+++ b/Tests/JSONAPISwiftGenTests/StructureSwiftGenTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import XCTest
-import OpenAPIKit
+import OpenAPIKit30
 @testable import JSONAPISwiftGen
 
 class StructureSwiftGenTests: XCTestCase {

--- a/Tests/JSONAPISwiftGenTests/TestFunctionLocalContextTests.swift
+++ b/Tests/JSONAPISwiftGenTests/TestFunctionLocalContextTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import XCTest
-import OpenAPIKit
+import OpenAPIKit30
 import JSONAPISwiftGen
 
 final class TestFunctionLocalContextTests: XCTestCase {

--- a/Tests/JSONAPISwiftGenTests/TestFunctionNameTests.swift
+++ b/Tests/JSONAPISwiftGenTests/TestFunctionNameTests.swift
@@ -6,7 +6,7 @@
 //
 
 import JSONAPISwiftGen
-import OpenAPIKit
+import OpenAPIKit30
 import XCTest
 
 final class TestFunctionNameTests: XCTestCase {

--- a/Tests/JSONAPIVizGenTests/JSONAPIVizGenTests.swift
+++ b/Tests/JSONAPIVizGenTests/JSONAPIVizGenTests.swift
@@ -7,7 +7,7 @@
 
 import JSONAPIVizGen
 import JSONAPISwiftGen
-import OpenAPIKit
+import OpenAPIKit30
 import XCTest
 
 final class JSONAPIVizGenTests: XCTestCase {


### PR DESCRIPTION
Merge after OpenAPIKit 3.0.0 is released.

This does not change to the OpenAPI 3.1.x format (yet), it continues to use OpenAPI 3.0.x.